### PR TITLE
To avoid SQL timeouts, avoid using Sierra's subfield view

### DIFF
--- a/lib/ybp_holdings_service/institution.rb
+++ b/lib/ybp_holdings_service/institution.rb
@@ -23,7 +23,8 @@ module YBPHoldingsService
     module Paths
       WORKDIR = File.join(__dir__, '..', '..', 'data')
       EBOOK_BNUMS = File.join(WORKDIR, 'results_non_ypb_ebook_ids.txt')
-      ALL_ISBNS = File.join(WORKDIR, 'results_all_isbns.txt')
+      RAW_ALL_ISBNS = File.join(WORKDIR, 'results_raw_all_isbns.txt')
+      PROCESSED_ALL_ISBNS = File.join(WORKDIR, 'results_all_isbns.txt')
       YBP_VENDOR = File.join(WORKDIR, 'results_ybp_vendor.txt')
       YBP_ECOLLS = File.join(WORKDIR, 'results_ybp_ecolls.txt')
       MANUAL_EXCLUDES = File.join(WORKDIR, 'EXCLUDES_gobi.txt')

--- a/lib/ybp_holdings_service/queries/all_isbns.sql
+++ b/lib/ybp_holdings_service/queries/all_isbns.sql
@@ -10,11 +10,10 @@ WITH excluded AS (
        inner join sierra_view.bib_record_item_record_link bil on bil.item_record_id = i.id
        where i.location_code = 'uadai'
     )
-select sf.record_id, sf.tag, sf.content
+select b.id, v.field_content
 from sierra_view.bib_record b
 inner join sierra_view.record_metadata rm on rm.id = b.id
-inner join sierra_view.subfield sf on sf.record_id = b.id
-  and sf.marc_tag = '020' and sf.tag in ('a', 'z')
+inner join sierra_view.varfield v on v.record_id = b.id and v.marc_tag = '020'
 where b.bcode3 != 'n'
       and (
             rm.creation_date_gmt < (localtimestamp - interval '30 days')
@@ -29,6 +28,6 @@ where b.bcode3 != 'n'
           )
       and NOT EXISTS (select *
                       from excluded
-                      where excluded.bib_id = sf.record_id)
+                      where excluded.bib_id = v.record_id)
 -- sorted input is needed by script to discard |z isbns appropriately
-order by b.id, sf.tag
+order by b.id

--- a/lib/ybp_holdings_service/queries/ybp_ecolls.sql
+++ b/lib/ybp_holdings_service/queries/ybp_ecolls.sql
@@ -1,8 +1,7 @@
-SELECT sf.content as isbn, v.field_content as coll
+SELECT phe.index_entry as isbn, v.field_content as coll
 FROM sierra_view.varfield v
-INNER JOIN sierra_view.subfield sf on sf.record_id = v.record_id
-    and sf.marc_tag = '020'
-    and sf.tag = 'a'
+INNER JOIN sierra_view.phrase_entry phe on phe.record_id = v.record_id
+  and phe.index_tag = 'i' and phe.phrase_rule_operation = 'K'
 WHERE v.marc_tag = '773'
     --changes to statement below need to also be reflected on ebook_bnums.sql
     and (v.field_content ilike '%title-by-title%'

--- a/lib/ybp_holdings_service/queries/ybp_vendor.sql
+++ b/lib/ybp_holdings_service/queries/ybp_vendor.sql
@@ -1,10 +1,9 @@
-select sf.content--, o.vendor_record_code
+select phe.index_entry--, o.vendor_record_code
 from sierra_view.order_record o
 inner join sierra_view.bib_record_order_record_link bl
   on bl.order_record_id = o.id
-inner join sierra_view.subfield sf on sf.record_id = bl.bib_record_id
-  and sf.marc_tag = '020'
-  and sf.tag ='a'
+inner join sierra_view.phrase_entry phe on phe.record_id = bl.bib_record_id
+  and phe.index_tag = 'i' and phe.phrase_rule_operation = 'K'
 where
     o.vendor_record_code ~ '^ya[0-9][0-9]'
 or  o.vendor_record_code like '9y%'


### PR DESCRIPTION
Our use of the `subfield` view is slow and sometimes causes the SQL queries to timeout. We replace it in two different ways:
- we use indexed isbn entries from `phrase_entry` in the excludes queries. There, we only care about 020|a and do not mind any bloating from variants (e.g. 10-, 13-digit isbns) that are automatically added to the index.
- we use `varfield` for the all_isbns query, where both the 020|a and 020|z are relevant, and we would rather avoid the bloat of variant-indexing (we don't need to supply variants, YBP matches across variants). Using `varfield` requires processing outside of SQL to break each field down into relevant subfields.