### PR TITLE
APPDEV-11571 exclude volatile collections

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GEM
     pg (1.5.4)
     pg (1.5.4-x64-mingw32)
     rake (12.3.3)
-    rexml (3.2.6)
+    rexml (3.4.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)

--- a/lib/ybp_holdings_service/queries/all_isbns.sql
+++ b/lib/ybp_holdings_service/queries/all_isbns.sql
@@ -1,14 +1,19 @@
---select 'b' || rm.record_num || 'a' as bnum, sfi.tag, sfi.content
---select sfi.record_id, sfi.tag, sfi.content
---from sierra_view.subfield sfi
---inner join sierra_view.record_metadata rm on rm.id = sfi.record_id
---where sfi.marc_tag = '020'
---  and sfi.tag in ('z', 'a')
 WITH excluded AS (
+       -- isbns from these records are not included in the holdings data
+       -- (but *can* still be included if present on other records)
        select bil.bib_record_id as bib_id
        from sierra_view.item_record i
        inner join sierra_view.bib_record_item_record_link bil on bil.item_record_id = i.id
        where i.location_code = 'uadai'
+
+       UNION
+
+       select b.id as bib_id
+       from sierra_view.bib_record b
+       inner join sierra_view.varfield v on v.record_id = b.id and v.marc_tag = '773'
+       where (v.field_content like '%|tOverDrive digital library (online collection). Ebooks%'
+          or v.field_content like '%|tOverDrive digital library (online collection). Audio books%'
+          or v.field_content like '%|tProQuest Ebook Central (online collection). NCLIVE subscription ebooks%')
     )
 select b.id, v.field_content
 from sierra_view.bib_record b


### PR DESCRIPTION
- ISBNs on bibs for certain eresource collections are not included in the holdings data (but may be included in holdings data if they are present on other records)
- Bump `rexml` gem per dependabot