### PR TITLE
APPDEV-11704: Do not copy archived files to network drive

### DIFF
--- a/lib/ybp_holdings_service/harvest.rb
+++ b/lib/ybp_holdings_service/harvest.rb
@@ -64,8 +64,6 @@ module YBPHoldingsService
       archive_files
       mailer.send_mail(email_address, email_subject, email_body,
                        [paths.adds, paths.deletes])
-
-      FileUtils.cp(@zipfile_path, paths.common_dir)
     end
 
     def az_stats(a_isbns, z_isbns, pre_exclusions_lengths)
@@ -238,8 +236,8 @@ module YBPHoldingsService
 
     def archive_files
       file_timestamp = Time.now.strftime('%F_%H%M%S')
-      @zipfile_path = File.join(paths::WORKDIR, "load_#{file_timestamp}.zip")
-      Zip::File.open(@zipfile_path, Zip::File::CREATE) do |zipfile|
+      zipfile_path = File.join(paths::WORKDIR, "load_#{file_timestamp}.zip")
+      Zip::File.open(zipfile_path, Zip::File::CREATE) do |zipfile|
         zipfile.add(File.basename(paths.adds), paths.adds)
         zipfile.add(File.basename(paths.deletes), paths.deletes)
         zipfile.add(File.basename(paths::COMPREHENSIVE_NEW), paths::COMPREHENSIVE_NEW)

--- a/lib/ybp_holdings_service/institution.rb
+++ b/lib/ybp_holdings_service/institution.rb
@@ -40,18 +40,6 @@ module YBPHoldingsService
       def self.deletes
         File.join(WORKDIR, "#{ACCT_TAG}_DELETES_holdings_load.txt")
       end
-
-      COMMON_SYMLINK = '/mnt/ybp_holdings_load/'
-      COMMON_FILEPATH = '\\\\ad.unc.edu\\lib\\common\\GOBI Library Solutions\\archive\\'
-
-      # Path where archival zip file is copied.
-      def self.common_dir
-        if File.directory?(Paths::COMMON_SYMLINK)
-          Paths::COMMON_SYMLINK
-        else
-          Paths::COMMON_FILEPATH
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
- APPDEV-11704: Remove copying of archived output to network drive (since it's unimportant and our network drive will become inaccessible)
